### PR TITLE
Use PhantomJS from Master branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "version": "1.0.3",
   "dependencies": {
-    "phantomjs": "latest",
+    "phantomjs": "ariya/phantomjs",
     "async": "latest",
     "tmp": "latest",
     "debug": "latest"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "version": "1.0.3",
   "dependencies": {
-    "phantomjs": "ariya/phantomjs",
+    "phantomjs": "git://github.com/ariya/phantomjs.git",
     "async": "latest",
     "tmp": "latest",
     "debug": "latest"


### PR DESCRIPTION
TL;DR links aren't clickable at the moment, it's scheduled for the 2.1 release but I need this immediately. It's been merged into master, see: https://github.com/ariya/phantomjs/issues/10196