### PR TITLE
Fix npm WARN: phantomjs renamed to phantomjs-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "version": "2.0.0",
   "dependencies": {
-    "phantomjs": "latest",
+    "phantomjs-prebuilt": "latest",
     "async": "latest",
     "tmp": "latest",
     "debug": "latest"


### PR DESCRIPTION
In it's current version, any package depending on phantom-html2pdf will:
- Not use the latest version of phantomjs
- Show a deprecation warning explaining that phantomjs is renamed to phantomjs-prebuild like this:
  `npm WARN deprecated phantomjs@2.1.3: Package renamed to phantomjs-prebuilt. Please update 'phantomjs' package references to 'phantomjs-prebuilt'
  `

This PR fixes this issue by taking into account the new name
