### PR TITLE
Fix regression in 2.0.1 (sorry)

### DIFF
--- a/lib/phantom-html2pdf.js
+++ b/lib/phantom-html2pdf.js
@@ -2,7 +2,7 @@
 
 var fs = require("fs"),
 	path = require("path"),
-	phantom = require("phantomjs"),
+	phantom = require("phantomjs-prebuilt"),
 	childProcess = require("child_process"),
 	tmp = require("tmp"),
 	async = require("async"),


### PR DESCRIPTION
Hi @dustin-H and really sorry but I introduced a regression in my last pull request.

I realised this when running the test suite of my projet with version 2.0.1 of phantom-html2pdf

The problem is that i forgot to rename the package in `lib/phantom-html2pdf.js`

This PR fixes the issue and I think it's not completely good (although a couple of automated tests wouldn't hurt). If you're interested, I can make a PR that adds automated tests...
