### PR TITLE
Add basic non - regression test for the most frequent usecase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-
-node_modules
+node_modules/
+.idea/
+coverage/

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
   "bin": {
     "phantom-html2pdf": "./bin/phantom-html2pdf"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "istanbul": "^0.4.2",
+    "mocha": "^2.4.5"
+  },
   "optionalDependencies": {},
   "engines": {
     "node": "*"
@@ -49,5 +52,8 @@
    {
       "name": "dustin-H"
    }
-  ]
+  ],
+  "scripts": {
+    "test": "istanbul cover _mocha --include-all-sources -x \"**/test/**\" -- --recursive"
+  }
 }

--- a/test/phantom-html2pdf.test.js
+++ b/test/phantom-html2pdf.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var assert = require('assert');
+
+var pdf = require('../lib/phantom-html2pdf');
+
+describe('phantom-html2pdf.js', function() {
+  describe('Simple end to end test', function() {
+
+    it('Should generate a PDF file without crashing', function(done) {
+      var pdfOptions = {
+        'html': '<!DOCTYPE html><html lang="en"><body><h1>Hello</h1><p>World</p></body></html>',
+        'papersize': {format: 'A4', orientation: 'portrait', border: '1cm'}
+      };
+
+      pdf.convert(pdfOptions, function (result) {
+        result.toBuffer(function (buffer) {
+          assert(buffer, 'A buffer is returned');
+          assert(buffer.length > 0, 'The generated buffer is not empty');
+          done();
+        });
+      });
+    });
+  })
+});


### PR DESCRIPTION
Changes highlights:

package.json
- Add devDependencies: _mocha_ (test runner) and _istanbul_ (to measure code
  coverage)
- Add npm test lifecycle script: now `npm test` will run the mocha tests,
  wrapped with istanbul to measure coverage. Test coverage is not amazing
  so far, but that's a start :=)
  
  Statements   : 46.21% ( 61/132 )
  Branches     : 49.3% ( 35/71 )
  Functions    : 53.57% ( 15/28 )
  Lines        : 49.18% ( 60/122 )

test/phantom-html2pdf.test.js: The test file for phantom-html2pdf.js
(todo: add tests for other files)

.gitignore: add the coverage files and the data directory of my favorite
IDE
