### PR TITLE
Fix for PhantomJS >= v2

### DIFF
--- a/lib/phantom-script.js
+++ b/lib/phantom-script.js
@@ -19,7 +19,11 @@ args = cmdArgs.reduce(function (args, name, i) {
     return args;
 }, {});
 
-page.open(page.libraryPath + "/skeleton.html", function (status) {
+// Fix for PhantomJS >= v2 requiring protocol specification
+var skeleton = page.libraryPath + "/skeleton.html"
+skeleton = phantom.version.major >= 2 ? "file://" + skeleton : skeleton
+
+page.open(skeleton, function (status) {
 
   if (status == "fail") {
     page.close();


### PR DESCRIPTION
Newer versions of Phantom require a protocol to be specified, so if version >= 2 add file:// protocol