### PR TITLE
Added an optional runningsArgs option to pass params to the runnings file

### DIFF
--- a/lib/phantom-html2pdf.js
+++ b/lib/phantom-html2pdf.js
@@ -27,8 +27,7 @@ function convert(options, callback) {
     runnings = options.runnings || '',
     deleteOnAction = options.deleteOnAction || false,
     paperSize = options.paperSize || {},
-	runningsArgs = options.runningsArgs || {};
-	runningsArgs = JSON.stringify(runningsArgs);
+	runningsArgs = options.runningsArgs ? JSON.stringify(options.runningsArgs) : '';
 
     /* Create temporary files for PDF, HTML, CSS and JS storage
      * We need to wait for all of them to finish creating the files before proceeding.

--- a/lib/phantom-html2pdf.js
+++ b/lib/phantom-html2pdf.js
@@ -26,7 +26,9 @@ function convert(options, callback) {
     js = options.js || '',
     runnings = options.runnings || '',
     deleteOnAction = options.deleteOnAction || false,
-    paperSize = options.paperSize || {};
+    paperSize = options.paperSize || {},
+	runningsArgs = options.runningsArgs || {};
+	runningsArgs = JSON.stringify(runningsArgs);
 
     /* Create temporary files for PDF, HTML, CSS and JS storage
      * We need to wait for all of them to finish creating the files before proceeding.
@@ -82,7 +84,8 @@ function convert(options, callback) {
 			paperBorder,
 			paperWidth,
 			paperHeight,
-			renderDelay
+			renderDelay,
+			runningsArgs
 		];
 
 		childProcess.execFile(phantom.path, childArgs, function(err, stdout, stderr) {

--- a/lib/phantom-script.js
+++ b/lib/phantom-script.js
@@ -69,8 +69,8 @@ page.open(skeleton, function (status) {
   page.paperSize = defaultFormat;
 
   if (args.runningsPath !== "nofile") {
-    var runningsArgs = JSON.parse(args.runningsArgs);
-    var runnings = require(args.runningsPath)(runningsArgs);
+    var runningsArgs = args.runningsArgs ? JSON.parse(args.runningsArgs) : undefined;
+    var runnings = runningsArgs ? require(args.runningsPath)(runningsArgs) : require(args.runningsPath);
     page.paperSize = paperSize(runnings, defaultFormat);
   }
 

--- a/lib/phantom-script.js
+++ b/lib/phantom-script.js
@@ -12,7 +12,8 @@ var cmdArgs = ["htmlPath",
              "paperBorder",
              "paperWidth",
              "paperHeight",
-             "renderDelay"];
+             "renderDelay",
+             "runningsArgs"];
 
 args = cmdArgs.reduce(function (args, name, i) {
     args[name] = system.args[i + 1];
@@ -68,7 +69,8 @@ page.open(skeleton, function (status) {
   page.paperSize = defaultFormat;
 
   if (args.runningsPath !== "nofile") {
-    var runnings = require(args.runningsPath);
+    var runningsArgs = JSON.parse(args.runningsArgs);
+    var runnings = require(args.runningsPath)(runningsArgs);
     page.paperSize = paperSize(runnings, defaultFormat);
   }
 


### PR DESCRIPTION
The `runningsArgs` option passes an object of parameters to the runnings file, thereby allowing the creation of headers and footers containing variables passed in from elsewhere in the app.

In order for the runnings file to accept this argument, the returned object needs to be wrapped in a function with one parameter like so:
```javascript
module.exports = function runnings(args) {
	return {
		footer: {
			height: '1cm',
			contents: function(pageNum, totalPages) {
				return [
					'<footer>',
					'<p>'+ args.userName + ' (Page ' + pageNum + ' of '+ totalPages +')</p>',
					'</footer>'
				].join('');
			}
		}
	};
};
```
The above example assumes that the `runningsArgs` option was passed an object, containing the property `userName`. E.g.:
```javascript
var params = {
	userName: 'some.user'
};

var options = {
	html: '<h1>Sample</h1>',
	paperSize: {format: 'Letter', orientation: 'portrait', border: '1cm'},
	runnings: 'runnings.js',
	runningsArgs: params
};

pdf.convert(options, function(err, result){});
```