### PR TITLE
Combined callback and promise implementations

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,6 +1,9 @@
 
 # FAQ:
 
+- [How to set a header and footer on each page?](FAQ.md#How to set a header and footer on each page?)
+- [How to set Custom Fonts?](FAQ.md#How to set Custom Fonts?)
+
 ## How to set a header and footer on each page?
 
 > Thanks to @faisalshabbir for this information!
@@ -22,3 +25,15 @@ module.exports = {
 
 }
 ```
+
+## How to set Custom Fonts?
+
+> Thanks to @befreestudios for this information!
+
+Custom fonts on PhantomJS step-by-step for Ubuntu:
+
+- Get a Type1 version of the font you need. I needed to do a conversion from TrueType— there are lots of tools to do this with.
+- Upload your Type1 font to your ‘/usr/share/fonts/type1' directory.
+- Run ‘fc-cache -fv’
+- Enjoy having PhantomJS with your new font.
+

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,24 @@
+
+# FAQ:
+
+## How to set a header and footer on each page?
+
+> Thanks to @faisalshabbir for this information!
+
+Runnings file should look like this. `module.exports` will fix the problem for us. 
+```
+module.exports = {
+    header: {
+        height: '3cm', contents: function (page) {
+            return '<header class="pdf-header" style=" overflow:hidden; font-size: 10px; padding: 10px; margin: 0 -15px; color: #fff; background: none repeat scroll 0 0 #00396f;"><img style="float: left;" alt="" src="../images/logo.jpg"><p> XYZ </p></header>'
+        }
+    },
+
+    footer: {
+        height: '3cm', contents: function (page) {
+            return '<footer class="pdf-footer" style="font-size: 10px; font-weight: bold; color: #000;><p style="margin: 0">Powered by XYZ</p></footer>'
+        }
+    },
+
+}
+```

--- a/README.md
+++ b/README.md
@@ -81,16 +81,7 @@ https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage#wiki-webpage-paper
 On Macs the generated PDF is going to be a bitmap, however it works perfectly fine on Linux and Windows Servers.
 So be careful when developing and testing on Macs; it's going to work in production :-)
 
-## Custom Fonts
-
-*Custom fonts on PhantomJS step-by-step for Ubuntu*
-
-- Get a Type1 version of the font you need. I needed to do a conversion from TrueType— there are lots of tools to do this with.
-- Upload your Type1 font to your ‘/usr/share/fonts/type1' directory.
-- Run ‘fc-cache -fv’
-- Enjoy having PhantomJS with your new font.
-
-Thanks to @befreestudios for this!
+## [FAQ](FAQ.md)
 
 ## License
 

--- a/lib/phantom-html2pdf-promise.js
+++ b/lib/phantom-html2pdf-promise.js
@@ -1,0 +1,114 @@
+"use strict";
+
+var fs = require("fs"),
+  path = require("path"),
+  phantom = require("phantomjs-prebuilt"),
+  childProcess = require("child_process"),
+  Promise = require('bluebird'),
+  tmp = require("tmp"),
+  debug = require('debug')('phantom-html2pdf'),
+  PDFResult = require("./pdfResult.js");
+
+/* Evaluates and converts input HTML, CSS and JS to PDF
+ *
+ * Returns Promise
+ *
+ */
+
+function convert(options) {
+  options = options || {};
+
+  var html = options.html || '<p>No HTML source specified!</p>',
+    css = options.css || '',
+    js = options.js || '',
+    runnings = options.runnings || '',
+    keepTmpFiles = options.keepTmpFiles === true,
+    paperSize = options.paperSize || {},
+    runningsArgs = options.runningsArgs ? JSON.stringify(options.runningsArgs) : '';
+
+  /* Create temporary files for PDF, HTML, CSS and JS storage
+   * We need to wait for all of them to finish creating the files before proceeding.
+   */
+
+  var p1 = createTempFile('.html', html),
+    p2 = createTempFile('.pdf', ''),
+    p3 = css ? createTempFile('.css', css) : undefined,
+    p4 = js ? createTempFile('.js', js) : undefined,
+    p5 = runnings ? createTempFile('.runnings.js', runnings) : 'nofile';
+
+  return Promise.all([p1, p2, p3, p4, p5]).then(function (results) {
+
+    var paperFormat = paperSize.format || "A4",
+      paperOrientation = paperSize.orientation || "portrait",
+      paperBorder = paperSize.border || "1cm",
+      paperWidth = paperSize.width || 'false',
+      paperHeight = paperSize.height || 'false',
+      renderDelay = paperSize.delay || 500;
+
+    /* All necessary files have been created.
+     * Construct arguments and create a new phantom process.
+     */
+    var childArgs = [
+      path.join(__dirname, "phantom-script.js"),
+      results[0],
+      results[1],
+      results[2],
+      results[3],
+      results[4],
+      paperFormat,
+      paperOrientation,
+      paperBorder,
+      paperWidth,
+      paperHeight,
+      renderDelay,
+      runningsArgs
+    ];
+
+    return new Promise(function (resolve, reject) {
+      childProcess.execFile(phantom.path, childArgs, function (err) {
+        var opPointer = new PDFResult(err, results[1]);
+        return err ? reject(err) : resolve(opPointer);
+      });
+    });
+  });
+
+  function createTempFile(extension, contents) {
+    return new Promise(function (resolve, reject) {
+      var needsTempFile = false;
+
+      try {
+        if (fs.lstatSync(path.resolve(contents)).isFile()) {
+          debug('Found file "%s"', contents);
+          resolve(path.resolve(contents));
+        } else {
+          needsTempFile = true;
+        }
+      } catch (err) {
+        needsTempFile = true;
+      }
+
+      if (needsTempFile) {
+        debug('Creating temp %s...', extension);
+
+        tmp.file({postfix: extension, keep: keepTmpFiles}, function (err, tmpPath, tmpFd) {
+          if (err) {
+            reject(err);
+          }
+
+          var buffer = new Buffer(contents);
+
+          fs.write(tmpFd, buffer, 0, buffer.length, null, function (err) {
+            if (err) {
+              debug('Could not create temp file! %s', err);
+            }
+
+            fs.close(tmpFd);
+            resolve(tmpPath);
+          });
+        });
+      }
+    });
+  }
+}
+
+exports.convert = convert;

--- a/lib/phantom-html2pdf.js
+++ b/lib/phantom-html2pdf.js
@@ -4,10 +4,11 @@ var fs = require("fs"),
   path = require("path"),
   phantom = require("phantomjs-prebuilt"),
   childProcess = require("child_process"),
-  Promise = require('bluebird'),
+  async = require("async"),
   tmp = require("tmp"),
   debug = require('debug')('phantom-html2pdf'),
-  PDFResult = require("./pdfResult.js");
+  PDFResult = require("./pdfResult.js"),
+  html2pdfPromise = require('./phantom-html2pdf-promise');
 
 /* TODO: Add config for HTML2PDF class.
  * Including path to skeleton html file
@@ -15,14 +16,20 @@ var fs = require("fs"),
 
 /* Evaluates and converts input HTML, CSS and JS to PDF
  *
- * Returns Promise
+ * Callback format: callback(err, result)
+ * If err === null, function succeeded.
+ *
+ * If no callback function is passed in, returns Promise
  *
  */
 
-function convert(options) {
-  options = options || {};
+function convert(options, callback) {
+  if (typeof callback !== 'function') {
+    return html2pdfPromise.convert(options);
+  }
 
-  var html = options.html || '<p>No HTML source specified!</p>',
+  var options = options || {},
+    html = options.html || '<p>No HTML source specified!</p>',
     css = options.css || '',
     js = options.js || '',
     runnings = options.runnings || '',
@@ -33,85 +40,99 @@ function convert(options) {
   /* Create temporary files for PDF, HTML, CSS and JS storage
    * We need to wait for all of them to finish creating the files before proceeding.
    */
-
-  var p1 = createTempFile('.html', html),
-    p2 = createTempFile('.pdf', ''),
-    p3 = css ? createTempFile('.css', css) : undefined,
-    p4 = js ? createTempFile('.js', js) : undefined,
-    p5 = runnings ? createTempFile('.runnings.js', runnings) : 'nofile';
-
-  return Promise.all([p1, p2, p3, p4, p5]).then(function (results) {
-
-    var paperFormat = paperSize.format || "A4",
-      paperOrientation = paperSize.orientation || "portrait",
-      paperBorder = paperSize.border || "1cm",
-      paperWidth = paperSize.width || 'false',
-      paperHeight = paperSize.height || 'false',
-      renderDelay = paperSize.delay || 500;
-
-    /* All necessary files have been created.
-     * Construct arguments and create a new phantom process.
+  async.series([
+      function(callback) {
+        createTempFile(".html", html, callback);
+      },
+      /* PDF file is necessary for further access within Node */
+      function(callback) {
+        createTempFile(".pdf", "", callback);
+      },
+      /* Create optional CSS injection file */
+      function(callback) {
+        (css) ? createTempFile(".css", css, callback) : callback(null, null);
+      },
+      /* Create optional JS injection file */
+      function(callback) {
+        (js) ? createTempFile(".js", js, callback) : callback(null, null);
+      },
+      /* Create runnings (JSON header, footer) file */
+      function(callback) {
+        (runnings) ? createTempFile(".runnings.js", runnings, callback) : callback(null, "nofile");
+      },
+    ],
+    /* err/results-Structure
+     * [0] = HTML temp file
+     * [1] = PDF temp file
+     * [2] = CSS temp file
+     * [3] = JS temp file
+     * [4] = Runnings temp file
      */
-    var childArgs = [
-      path.join(__dirname, "phantom-script.js"),
-      results[0],
-      results[1],
-      results[2],
-      results[3],
-      results[4],
-      paperFormat,
-      paperOrientation,
-      paperBorder,
-      paperWidth,
-      paperHeight,
-      renderDelay,
-      runningsArgs
-    ];
+    function(err, results) {
+      var paperFormat = paperSize.format || "A4";
+      var paperOrientation = paperSize.orientation || "portrait";
+      var paperBorder = paperSize.border || "1cm";
+      var paperWidth  = paperSize.width || 'false';
+      var paperHeight = paperSize.height || 'false';
+      var renderDelay = paperSize.delay || 500;
 
-    return new Promise(function (resolve, reject) {
-      childProcess.execFile(phantom.path, childArgs, function (err) {
+      /* All necessary files have been created.
+       * Construct arguments and create a new phantom process.
+       */
+      var childArgs = [
+        path.join(__dirname, "phantom-script.js"),
+        results[0],
+        results[1],
+        results[2],
+        results[3],
+        results[4],
+        paperFormat,
+        paperOrientation,
+        paperBorder,
+        paperWidth,
+        paperHeight,
+        renderDelay,
+        runningsArgs
+      ];
+
+      childProcess.execFile(phantom.path, childArgs, function(err, stdout, stderr) {
         var opPointer = new PDFResult(err, results[1]);
-        return err ? reject(err) : resolve(opPointer);
+
+        if (typeof callback === "function") {
+          callback(err, opPointer);
+        }
       });
     });
-  });
+  function createTempFile(extension, contents, callback)
+  {
+    var needsTempFile = false;
 
-  function createTempFile(extension, contents) {
-    return new Promise(function (resolve, reject) {
-      var needsTempFile = false;
-
-      try {
-        if (fs.lstatSync(path.resolve(contents)).isFile()) {
-          debug('Found file "%s"', contents);
-          resolve(path.resolve(contents));
-        } else {
-          needsTempFile = true;
-        }
-      } catch (err) {
+    try {
+      if (fs.lstatSync(path.resolve(contents)).isFile()) {
+        debug('Found file "%s"', contents);
+        callback(null, path.resolve(contents));
+      } else {
         needsTempFile = true;
       }
+    } catch (err) {
+      needsTempFile = true;
+    }
 
-      if (needsTempFile) {
-        debug('Creating temp %s...', extension);
+    if (needsTempFile) {
+      debug('Creating temp %s...', extension);
+      tmp.file({postfix: extension, keep: keepTmpFiles}, function (err, tmpPath, tmpFd) {
+        if (err) { callback(err, null); }
 
-        tmp.file({postfix: extension, keep: keepTmpFiles}, function (err, tmpPath, tmpFd) {
-          if (err) {
-            reject(err);
-          }
+        var buffer = new Buffer(contents);
 
-          var buffer = new Buffer(contents);
+        fs.write(tmpFd, buffer, 0, buffer.length, null, function(err, written, buffer) {
+          if (err) { debug('Could not create temp file! %s', err); }
 
-          fs.write(tmpFd, buffer, 0, buffer.length, null, function (err) {
-            if (err) {
-              debug('Could not create temp file! %s', err);
-            }
-
-            fs.close(tmpFd);
-            resolve(tmpPath);
-          });
+          fs.close(tmpFd);
+          callback(null, tmpPath);
         });
-      }
-    });
+      });
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
   ],
   "version": "3.0.0",
   "dependencies": {
-    "async": "^2.1.2",
-    "bluebird": "^3.4.6",
+    "async": "latest",
+    "tmp": "latest",
     "debug": "latest",
     "phantomjs-prebuilt": "latest",
-    "tmp": "latest"
+    "bluebird": "^3.4.6"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "version": "3.0.0",
   "dependencies": {
+    "async": "^2.1.2",
     "bluebird": "^3.4.6",
     "debug": "latest",
     "phantomjs-prebuilt": "latest",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
       "email": "samuel.rossille@gmail.com"
     }
   ],
-  "version": "2.0.2",
+  "version": "3.0.0",
   "dependencies": {
     "phantomjs-prebuilt": "latest",
     "async": "latest",


### PR DESCRIPTION
- Moved the promise implementation into a separate file: lib/phantom-html2pdf-promise.js.
- If a callback function is not provided to `convert()`, a Promise is returned instead. E.g.:

``` javascript
pdf.convert({}, function(err, result){}); // same behavior as before

pdf.convert({}) // returns Promise
```

@dustin-H: let me know if you think this is a reasonable way to offer both callbacks and promises. If not, we can discuss which changes you'd like to see made.
